### PR TITLE
Fixed route loader type inference lost

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,3 +9,9 @@ export const router = createRouter({
     queryClient: undefined!,
   },
 });
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}


### PR DESCRIPTION
If you create a route with a loader function, type inference is lost when using the data. 

Normally `Route.useLoaderData()` uses type inference from the loader, but without the module TS code I added, it does not work. 

Example route:

```ts
export const Route = createFileRoute(
  "/_app/freelance/my-applications/_layout/$applicationId",
)({
  component: RouteComponent,
  loader: async () => {
    return {
      a: 'test',
      b: 123,
      c: true,
    }
  },
});

function RouteComponent() {
  // This data was previously typed as `any`
  const data = Route.useLoaderData();
  return (
    <div className="flex flex-1 flex-col h-full">
      <p>hello</p>
    </div>
  );
}
```

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
