### PR TITLE
fix: use @cvx alias for _generated/api import in stripe.ts

### DIFF
--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -9,7 +9,7 @@ import { v } from "convex/values";
 import { ERRORS } from "~/errors";
 import { auth } from "@cvx/auth";
 import { currencyValidator, intervalValidator, PLANS } from "@cvx/schema";
-import { api, internal } from "~/convex/_generated/api";
+import { api, internal } from "@cvx/_generated/api";
 import { SITE_URL, STRIPE_SECRET_KEY } from "@cvx/env";
 import { asyncMap } from "convex-helpers";
 


### PR DESCRIPTION
## Summary

- `convex/stripe.ts` imports `{ api, internal }` from `~/convex/_generated/api`, which is inconsistent with every other generated import in the codebase (all of which use `@cvx/_generated/api`)
- `~/convex/_generated/api` resolves to the same file via the root `~` alias, but tools that only understand the `@cvx/*` alias (such as `npx @convex-dev/auth`) fail to bundle the file with the error `Could not resolve "~/convex/_generated/api"`
- This one-line fix aligns the import with the canonical `@cvx/_generated/api` pattern used everywhere else

## Test plan

- [ ] Run `npx @convex-dev/auth` — bundling errors for `convex/stripe.ts` should be gone
- [ ] Run `npm start` — `convex dev` should bundle without path-resolution errors
- [ ] Verify Stripe checkout and webhook flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)